### PR TITLE
LC 2637 cache ttl

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/config/RedisCacheConfig.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/config/RedisCacheConfig.java
@@ -1,0 +1,28 @@
+package uk.gov.cabinetoffice.csl.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Value("${learnerRecord.cache.ttlSeconds}")
+    private int learnerRecordCacheTTlSeconds;
+
+    @Value("${learningCatalogue.cache.ttlSeconds}")
+    private int learningCatalogueCacheTTlSeconds;
+
+    @Bean
+    public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+        return (builder) -> builder
+                .withCacheConfiguration("course-record",
+                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofSeconds(learnerRecordCacheTTlSeconds)))
+                .withCacheConfiguration("catalogue-course",
+                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofSeconds(learningCatalogueCacheTTlSeconds)));
+    }
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/CacheResetController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/CacheResetController.java
@@ -34,12 +34,6 @@ public class CacheResetController {
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 
-    @GetMapping(path = "/all-courses", produces = "application/json")
-    public ResponseEntity<?> removeAllCoursesFromCache() {
-        learningCatalogueService.removeAllCoursesFromCache();
-        return new ResponseEntity<>(HttpStatus.ACCEPTED);
-    }
-
     @GetMapping(path = "/course/{courseId}", produces = "application/json")
     public ResponseEntity<?> removeCoursesFromCache(@PathVariable String courseId) {
         learningCatalogueService.removeCourseFromCache(courseId);

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/LearningCatalogueService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/LearningCatalogueService.java
@@ -2,7 +2,6 @@ package uk.gov.cabinetoffice.csl.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.gov.cabinetoffice.csl.client.courseCatalogue.ILearningCatalogueClient;
 import uk.gov.cabinetoffice.csl.domain.error.LearningCatalogueResourceNotFoundException;
@@ -33,18 +32,12 @@ public class LearningCatalogueService {
             }
         }
     }
-    
+
     public Course getCourse(String courseId) {
         Course course = client.getCourse(courseId);
         log.info("Course is retrieved from the Learning-catalogue for the course id: {}", courseId);
         log.debug(course.toString());
         return course;
-    }
-
-    @Scheduled(cron = "${learningCatalogue.courseCacheEvictionScheduleCron}")
-    @CacheEvict(value = "catalogue-course", allEntries = true)
-    public void removeAllCoursesFromCache() {
-        log.info("LearningCatalogueService.removeAllCoursesFromCache: All catalogue courses are removed from the cache");
     }
 
     @CacheEvict(value = "catalogue-course", key = "#courseId")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,8 +46,9 @@ oauth.refresh.serviceTokenCache.beforeSecondsToExpire=${REFRESH_SERVICETOKENCACH
 learnerRecord.serviceUrl=${LEARNER_RECORD_SERVICE_URL:ChangeMe}
 learnerRecord.courseRecordsForLearnerUrl=/course_records
 learnerRecord.moduleRecordsForLearnerUrl=/module_records
+learnerRecord.cache.ttlSeconds=${LEARNER_RECORD_CACHE_TTL_SECONDS:86400}
 ## learning-catalogue service properties
-learningCatalogue.courseCacheEvictionScheduleCron=${COURSE_CACHE_EVICTION_SCHEDULE_CRON:@daily}
+learningCatalogue.cache.ttlSeconds=${COURSE_CACHE_TTL_SECONDS:86400}
 learningCatalogue.serviceUrl=${LEARNING_CATALOGUE_SERVICE_URL:ChangeMe}
 learningCatalogue.courseUrl=/courses
 ## rustici service properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,7 @@ spring.data.redis.password=${REDIS_PASSWORD:ChangeMe}
 spring.cache.redis.key-prefix=${REDIS_KEY_PREFIX:csl_}
 spring.cache.redis.use-key-prefix=${REDIS_USE_KEY_PREFIX:true}
 spring.cache.redis.cache-null-values=${REDIS_CACHE_NULL_VALUES:false}
+spring.cache.redis.time-to-live=${REDIS_CACHE_DEFAULT_TTL:3600000}
 # API data
 ## jackson
 spring.jackson.serialization.write-dates-as-timestamps=false


### PR DESCRIPTION
- TTL settings for course cache and course record cache
   - Default global cache expiry of 1 hour
   - Default expiry for course/course records 24 hours
- Remove cron schedule for deleting all course cache entries 