### PR TITLE
LC-2001 past seven day filter

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1,0 +1,12 @@
+name: "Auto-create release backfills"
+
+on:
+  create:
+    branches:
+      - '*'
+
+jobs:
+  call-reusable-workflow:
+    uses: Civil-Service-Human-Resources/csl-devops-templates/.github/workflows/auto-backfill-template.yml@main
+    with:
+      source_branch: ${{ github.ref_name }}

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/model/GetCourseCompletionsParams.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/model/GetCourseCompletionsParams.java
@@ -8,7 +8,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import uk.gov.cabinetoffice.csl.domain.reportservice.AggregationBinDelimiter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Data
@@ -16,12 +17,19 @@ import java.util.List;
 @NoArgsConstructor
 public class GetCourseCompletionsParams {
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDate startDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startDate;
 
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDate endDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endDate;
+
+    @NotNull
+    private ZoneId timezone;
+
+    public String getTimezone() {
+        return timezone.toString();
+    }
 
     @Size(min = 1, max = 30)
     @NotNull

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/AggregationResponse.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/AggregationResponse.java
@@ -11,8 +11,8 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AggregationResponse<A extends Aggregation> {
-
+    private String timezone;
     private AggregationBinDelimiter delimiter;
     private List<A> results;
-    
+
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/aggregation/Aggregation.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/aggregation/Aggregation.java
@@ -4,12 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class Aggregation {
-    protected ZonedDateTime dateBin;
+    protected LocalDateTime dateBin;
     protected Integer total;
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/aggregation/CourseCompletionAggregation.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/aggregation/CourseCompletionAggregation.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 
 @EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
@@ -15,7 +15,7 @@ public class CourseCompletionAggregation extends Aggregation {
 
     private String courseId;
 
-    public CourseCompletionAggregation(ZonedDateTime dateBin, Integer total, String courseId) {
+    public CourseCompletionAggregation(LocalDateTime dateBin, Integer total, String courseId) {
         super(dateBin, total);
         this.courseId = courseId;
     }

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/chart/CourseCompletionChart.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/reportservice/chart/CourseCompletionChart.java
@@ -12,11 +12,13 @@ import java.util.Map;
 @AllArgsConstructor
 public class CourseCompletionChart extends BasicChart {
 
+    private String timezone;
     private Map<String, Integer> courseBreakdown;
     private Integer total;
 
-    public CourseCompletionChart(List<PlotPoint> chart, Map<String, Integer> courseBreakdown, Integer total) {
+    public CourseCompletionChart(List<PlotPoint> chart, Map<String, Integer> courseBreakdown, String timezone, Integer total) {
         super(chart);
+        this.timezone = timezone;
         this.courseBreakdown = courseBreakdown;
         this.total = total;
     }

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/ChartFactory.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/ChartFactory.java
@@ -43,7 +43,7 @@ public class ChartFactory {
             }
             courseIdBreakdown.put(courseId, courseTotal);
 
-            String stringedDateTime = result.getDateBin().format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+            String stringedDateTime = result.getDateBin().format(DateTimeFormatter.ISO_DATE_TIME);
             Integer count = totalResults.get(stringedDateTime);
             if (count == null) {
                 count = result.getTotal();
@@ -62,7 +62,7 @@ public class ChartFactory {
 
         List<PlotPoint> plotPoints = totalResults.entrySet().stream()
                 .map(e -> new PlotPoint(e.getKey(), e.getValue())).toList();
-        return new CourseCompletionChart(plotPoints, courseTitleBreakdown, courseSummaryTotal);
+        return new CourseCompletionChart(plotPoints, courseTitleBreakdown, params.getTimezone(), courseSummaryTotal);
     }
 
 }

--- a/src/test/java/uk/gov/cabinetoffice/csl/integration/ReportTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/integration/ReportTest.java
@@ -34,55 +34,57 @@ public class ReportTest extends CSLServiceWireMockServer {
     public void testGetAggregations() {
         String response = """
                 {
+                  "timezone": "Europe/London",
                   "delimiter": "hour",
                   "results": [
                     {
                       "courseId": "course1",
                       "total": 10,
-                      "dateBin": "2024-01-01T10:00:00Z"
+                      "dateBin": "2024-01-01T10:00:00"
                     },
                     {
                       "courseId": "course2",
                       "total": 14,
-                      "dateBin": "2024-01-01T10:00:00Z"
+                      "dateBin": "2024-01-01T10:00:00"
                     },
                     {
                       "courseId": "course1",
                       "total": 50,
-                      "dateBin": "2024-01-01T11:00:00Z"
+                      "dateBin": "2024-01-01T11:00:00"
                     },
                     {
                       "courseId": "course2",
                       "total": 20,
-                      "dateBin": "2024-01-01T11:00:00Z"
+                      "dateBin": "2024-01-01T11:00:00"
                     },
                     {
                       "courseId": "course1",
                       "total": 13,
-                      "dateBin": "2024-01-01T12:00:00Z"
+                      "dateBin": "2024-01-01T12:00:00"
                     },
                     {
                       "courseId": "course2",
                       "total": 90,
-                      "dateBin": "2024-01-01T12:00:00Z"
+                      "dateBin": "2024-01-01T12:00:00"
                     },
                     {
                       "courseId": "course1",
                       "total": 12,
-                      "dateBin": "2024-01-01T13:00:00Z"
+                      "dateBin": "2024-01-01T13:00:00"
                     },
                     {
                       "courseId": "course2",
                       "total": 9,
-                      "dateBin": "2024-01-01T13:00:00Z"
+                      "dateBin": "2024-01-01T13:00:00"
                     }
                   ]
                 }
                 """;
         String expectedInput = """
                 {
-                    "startDate":"2024-05-08",
-                    "endDate":"2024-05-09",
+                    "startDate":"2024-05-08T00:00:00",
+                    "endDate":"2024-05-09T00:00:00",
+                    "timezone": "Europe/London",
                     "courseIds":["course1", "course2"],
                     "organisationIds":["1","2"],
                     "binDelimiter":"HOUR"
@@ -109,15 +111,16 @@ public class ReportTest extends CSLServiceWireMockServer {
                 .is2xxSuccessful()
                 .expectBody()
                 .consumeWith(System.out::println)
-                .jsonPath("$.chart[0].x").isEqualTo("2024-01-01T10:00:00Z[UTC]")
+                .jsonPath("$.chart[0].x").isEqualTo("2024-01-01T10:00:00")
                 .jsonPath("$.chart[0].y").isEqualTo("24")
-                .jsonPath("$.chart[1].x").isEqualTo("2024-01-01T11:00:00Z[UTC]")
+                .jsonPath("$.chart[1].x").isEqualTo("2024-01-01T11:00:00")
                 .jsonPath("$.chart[1].y").isEqualTo("70")
-                .jsonPath("$.chart[2].x").isEqualTo("2024-01-01T12:00:00Z[UTC]")
+                .jsonPath("$.chart[2].x").isEqualTo("2024-01-01T12:00:00")
                 .jsonPath("$.chart[2].y").isEqualTo("103")
-                .jsonPath("$.chart[3].x").isEqualTo("2024-01-01T13:00:00Z[UTC]")
+                .jsonPath("$.chart[3].x").isEqualTo("2024-01-01T13:00:00")
                 .jsonPath("$.chart[3].y").isEqualTo("21")
                 .jsonPath("$.total").isEqualTo("218")
+                .jsonPath("$.timezone").isEqualTo("Europe/London")
                 .jsonPath("$.courseBreakdown[\"Course 1 title\"]").isEqualTo("85")
                 .jsonPath("$.courseBreakdown[\"Course 2 title\"]").isEqualTo("133");
     }

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/ChartFactoryTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/ChartFactoryTest.java
@@ -12,8 +12,8 @@ import uk.gov.cabinetoffice.csl.domain.reportservice.AggregationResponse;
 import uk.gov.cabinetoffice.csl.domain.reportservice.aggregation.CourseCompletionAggregation;
 import uk.gov.cabinetoffice.csl.domain.reportservice.chart.CourseCompletionChart;
 
+import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -51,9 +51,8 @@ class ChartFactoryTest {
                 add(course4);
             }
         };
-        ZoneId zone = ZoneId.of("UTC");
-        ZonedDateTime date1 = ZonedDateTime.of(2024, 1, 1, 10, 0, 0, 0, zone);
-        ZonedDateTime date2 = ZonedDateTime.of(2024, 2, 1, 10, 0, 0, 0, zone);
+        LocalDateTime date1 = LocalDateTime.of(2024, 1, 1, 10, 0, 0, 0);
+        LocalDateTime date2 = LocalDateTime.of(2024, 2, 1, 10, 0, 0, 0);
         List<CourseCompletionAggregation> aggregations = new ArrayList<>();
         aggregations.add(new CourseCompletionAggregation(date1, 10, "course1"));
         aggregations.add(new CourseCompletionAggregation(date1, 17, "course2"));
@@ -61,17 +60,18 @@ class ChartFactoryTest {
         aggregations.add(new CourseCompletionAggregation(date2, 100, "course1"));
         aggregations.add(new CourseCompletionAggregation(date2, 21, "course2"));
         GetCourseCompletionsParams params = new GetCourseCompletionsParams();
+        params.setTimezone(ZoneId.of("Europe/London"));
         params.setCourseIds(List.of("course1", "course2", "course3", "course4"));
-        AggregationResponse<CourseCompletionAggregation> response = new AggregationResponse<>(AggregationBinDelimiter.MONTH, aggregations);
+        AggregationResponse<CourseCompletionAggregation> response = new AggregationResponse<>("Europe/London", AggregationBinDelimiter.MONTH, aggregations);
 
         when(learningCatalogueService.getCourses(List.of("course1", "course2", "course3", "course4"))).thenReturn(courses);
 
         CourseCompletionChart chart = factory.buildCourseCompletionsChart(params, response);
 
         assertEquals(190, chart.getTotal());
-        assertEquals("2024-01-01T10:00:00Z[UTC]", chart.getChart().get(0).getX());
+        assertEquals("2024-01-01T10:00:00", chart.getChart().get(0).getX());
         assertEquals(69, chart.getChart().get(0).getY());
-        assertEquals("2024-02-01T10:00:00Z[UTC]", chart.getChart().get(1).getX());
+        assertEquals("2024-02-01T10:00:00", chart.getChart().get(1).getX());
         assertEquals(121, chart.getChart().get(1).getY());
         assertEquals(110, chart.getCourseBreakdown().get("Course 1 title"));
         assertEquals(38, chart.getCourseBreakdown().get("Course 2 title"));


### PR DESCRIPTION
- Github auto-PR
- Refactor course completion aggregation endpoint to utlise timestamps instead of dates. This allows greater flexibility when querying, but more importantly makes it clear exactly when completions are being tracked
- Provide a `timezone` parameter so that report-service knows what timestamps/timezones to bucket the completions into