### PR TITLE
LC-3151 Add to learning plan bug

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/course/AddToLearningPlan.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/course/AddToLearningPlan.java
@@ -3,6 +3,7 @@ package uk.gov.cabinetoffice.csl.domain.learnerrecord.actions.course;
 import uk.gov.cabinetoffice.csl.domain.User;
 import uk.gov.cabinetoffice.csl.domain.learnerrecord.CourseRecord;
 import uk.gov.cabinetoffice.csl.domain.learnerrecord.Preference;
+import uk.gov.cabinetoffice.csl.domain.learnerrecord.State;
 import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Course;
 import uk.gov.cabinetoffice.csl.util.UtilService;
 
@@ -14,7 +15,8 @@ public class AddToLearningPlan extends CourseRecordActionProcessor {
 
     @Override
     public CourseRecord applyUpdatesToCourseRecord(CourseRecord courseRecord) {
-        courseRecord.setState(null);
+        State state = courseRecord.getModuleRecords().size() > 0 ? State.IN_PROGRESS : null;
+        courseRecord.setState(state);
         courseRecord.setPreference(Preference.LIKED);
         return courseRecord;
     }

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/event/CompleteBooking.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/event/CompleteBooking.java
@@ -11,6 +11,9 @@ import uk.gov.cabinetoffice.csl.service.notification.messages.NotifyLineManagerC
 import uk.gov.cabinetoffice.csl.util.UtilService;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 public class CompleteBooking extends EventModuleRecordActionProcessor {
@@ -28,7 +31,8 @@ public class CompleteBooking extends EventModuleRecordActionProcessor {
             throw new IncorrectStateException("Can't complete a booking that hasn't been approved");
         }
         LocalDateTime completionDate = utilService.getNowDateTime();
-        if (willModuleCompletionCompleteCourse(courseRecord)) {
+        List<String> remainingModules = new ArrayList<>(course.getRemainingModuleIdsForCompletion(courseRecord, user));
+        if (remainingModules.size() == 1 && Objects.equals(remainingModules.get(0), getModuleId())) {
             log.debug(String.format("Completing module %s will complete this course. Setting course record to completed and sending completion message", getModuleId()));
             courseRecord.setState(State.COMPLETED);
             addMessage(generateCompletionMessage(completionDate));
@@ -36,6 +40,12 @@ public class CompleteBooking extends EventModuleRecordActionProcessor {
                 addEmail(new NotifyLineManagerCompletedLearning(user.getLineManagerEmail(), user.getLineManagerName(),
                         user.getName(), user.getEmail(), course.getTitle()));
             }
+        } else if (remainingModules.size() == 0 && !courseRecord.getState().equals(State.COMPLETED)) {
+            log.debug("Course was already completed but course record status is not set to COMPLETED, setting status to COMPLETED.");
+            courseRecord.setState(State.COMPLETED);
+        } else if (courseRecord.getState().equals(State.NULL) ||
+                courseRecord.getState().equals(State.ARCHIVED)) {
+            courseRecord.setState(State.IN_PROGRESS);
         }
         moduleRecord.setState(State.COMPLETED);
         moduleRecord.setCompletionDate(completionDate);

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/CompleteModule.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/CompleteModule.java
@@ -10,6 +10,9 @@ import uk.gov.cabinetoffice.csl.service.notification.messages.NotifyLineManagerC
 import uk.gov.cabinetoffice.csl.util.UtilService;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 public class CompleteModule extends ModuleRecordActionProcessor {
@@ -22,7 +25,8 @@ public class CompleteModule extends ModuleRecordActionProcessor {
     public CourseRecord updateCourseRecord(CourseRecord courseRecord) {
         ModuleRecord moduleRecord = courseRecord.getOrCreateModuleRecord(module);
         LocalDateTime completionDate = utilService.getNowDateTime();
-        if (willModuleCompletionCompleteCourse(courseRecord)) {
+        List<String> remainingModules = new ArrayList<>(course.getRemainingModuleIdsForCompletion(courseRecord, user));
+        if (remainingModules.size() == 1 && Objects.equals(remainingModules.get(0), getModuleId())) {
             log.debug(String.format("Completing module %s will complete this course. Setting course record to completed and sending completion message", getModuleId()));
             courseRecord.setState(State.COMPLETED);
             addMessage(generateCompletionMessage(completionDate));
@@ -30,6 +34,9 @@ public class CompleteModule extends ModuleRecordActionProcessor {
                 addEmail(new NotifyLineManagerCompletedLearning(user.getLineManagerEmail(), user.getLineManagerName(),
                         user.getName(), user.getEmail(), course.getTitle()));
             }
+        } else if (remainingModules.size() == 0 && !courseRecord.getState().equals(State.COMPLETED)) {
+            log.debug("Course was already completed but course record status is not set to COMPLETED, setting status to COMPLETED.");
+            courseRecord.setState(State.COMPLETED);
         } else if (courseRecord.getState().equals(State.NULL) ||
                 courseRecord.getState().equals(State.ARCHIVED)) {
             courseRecord.setState(State.IN_PROGRESS);

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/ModuleRecordActionProcessor.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/ModuleRecordActionProcessor.java
@@ -11,8 +11,6 @@ import uk.gov.cabinetoffice.csl.service.messaging.model.CourseCompletionMessage;
 import uk.gov.cabinetoffice.csl.util.UtilService;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -39,13 +37,6 @@ public abstract class ModuleRecordActionProcessor extends CourseRecordActionProc
 
     protected String getModuleId() {
         return module.getId();
-    }
-
-    protected boolean willModuleCompletionCompleteCourse(CourseRecord courseRecord) {
-        log.debug(String.format("Checking if %s completion will complete course", module.getId()));
-        List<String> remainingModules = new ArrayList<>(course.getRemainingModuleIdsForCompletion(courseRecord, user));
-        log.debug(String.format("Remaining modules left for completion: %s", remainingModules));
-        return (remainingModules.size() == 1 && Objects.equals(remainingModules.get(0), getModuleId()));
     }
 
     protected CourseCompletionMessage generateCompletionMessage(LocalDateTime completionDate) {

--- a/src/test/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/course/AddToLearningPlanTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/course/AddToLearningPlanTest.java
@@ -17,9 +17,18 @@ public class AddToLearningPlanTest extends BaseCourseRecordActionTest<AddToLearn
     @Test
     public void testAddToLearningPlan() {
         CourseRecord cr = new CourseRecord();
-        cr.setState(State.IN_PROGRESS);
+        cr.setState(State.ARCHIVED);
         cr = actionUnderTest.applyUpdatesToCourseRecord(cr);
         assertEquals(Preference.LIKED, cr.getPreference());
         assertEquals(State.NULL, cr.getState());
+    }
+
+    @Test
+    public void testAddToLearningPlanInProgress() {
+        CourseRecord cr = this.generateCourseRecord(true);
+        cr.setState(State.ARCHIVED);
+        cr = actionUnderTest.applyUpdatesToCourseRecord(cr);
+        assertEquals(Preference.LIKED, cr.getPreference());
+        assertEquals(State.IN_PROGRESS, cr.getState());
     }
 }


### PR DESCRIPTION
- Sets the course record status to "in progress" if adding an in progress course back to the learning plan
- Completing a module will now check if the course was already completed before and will set the status back to completed if so