### PR TITLE
LC-3163 / LC-3164: Get profile full name

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/model/CreateReportRequestParams.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/model/CreateReportRequestParams.java
@@ -16,4 +16,6 @@ public class CreateReportRequestParams extends GetCourseCompletionsParams {
     @NotNull
     private String userEmail;
 
+    private String fullName;
+
 }


### PR DESCRIPTION
This change includes a `fullName` parameter for creating report requests. This parameter is included in the report service endpoint for creating report requests.