### PR TITLE
LC-3177 don't try to send notify email if the user doesn't have a line manager

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/User.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/User.java
@@ -52,4 +52,8 @@ public class User implements Serializable {
         return departmentHierarchy.stream().findFirst().map(BasicOrganisationalUnit::getName).orElse("");
     }
 
+    public boolean hasLineManager() {
+        return lineManagerEmail != null && lineManagerName != null;
+    }
+
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/event/CompleteBooking.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/event/CompleteBooking.java
@@ -36,7 +36,7 @@ public class CompleteBooking extends EventModuleRecordActionProcessor {
             log.debug(String.format("Completing module %s will complete this course. Setting course record to completed and sending completion message", getModuleId()));
             courseRecord.setState(State.COMPLETED);
             addMessage(generateCompletionMessage(completionDate));
-            if (course.isMandatoryLearningForUser(user)) {
+            if (user.hasLineManager() && course.isMandatoryLearningForUser(user)) {
                 addEmail(new NotifyLineManagerCompletedLearning(user.getLineManagerEmail(), user.getLineManagerName(),
                         user.getName(), user.getEmail(), course.getTitle()));
             }

--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/CompleteModule.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/CompleteModule.java
@@ -30,7 +30,7 @@ public class CompleteModule extends ModuleRecordActionProcessor {
             log.debug(String.format("Completing module %s will complete this course. Setting course record to completed and sending completion message", getModuleId()));
             courseRecord.setState(State.COMPLETED);
             addMessage(generateCompletionMessage(completionDate));
-            if (course.isMandatoryLearningForUser(user)) {
+            if (user.hasLineManager() && course.isMandatoryLearningForUser(user)) {
                 addEmail(new NotifyLineManagerCompletedLearning(user.getLineManagerEmail(), user.getLineManagerName(),
                         user.getName(), user.getEmail(), course.getTitle()));
             }


### PR DESCRIPTION
- new `user.hasLineManager()` method
- Check for the existance of a line manager before trying to send an email