### PR TITLE
LC-1340 remove from suggestions

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/ModuleRecordActionProcessor.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/ModuleRecordActionProcessor.java
@@ -28,6 +28,7 @@ public abstract class ModuleRecordActionProcessor extends CourseRecordActionProc
     @Override
     public CourseRecord applyUpdatesToCourseRecord(CourseRecord courseRecord) {
         CourseRecord updatedRecord = new CourseRecord(courseRecord.getCourseId(), courseRecord.getUserId(), courseRecord.getCourseTitle());
+        courseRecord.setPreference(null);
         updatedRecord.update(this.updateCourseRecord(courseRecord));
         updatedRecord.setModuleRecords(courseRecord.getModuleRecords().stream().filter(mr -> Objects.equals(mr.getModuleId(), getModuleId())).collect(Collectors.toSet()));
         return updatedRecord;

--- a/src/test/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/LaunchModuleTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/LaunchModuleTest.java
@@ -3,9 +3,11 @@ package uk.gov.cabinetoffice.csl.domain.learnerrecord.actions.module;
 import org.junit.jupiter.api.Test;
 import uk.gov.cabinetoffice.csl.domain.learnerrecord.CourseRecord;
 import uk.gov.cabinetoffice.csl.domain.learnerrecord.ModuleRecord;
+import uk.gov.cabinetoffice.csl.domain.learnerrecord.Preference;
 import uk.gov.cabinetoffice.csl.domain.learnerrecord.State;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LaunchModuleTest extends BaseModuleRecordActionTest<LaunchModule> {
 
@@ -20,6 +22,16 @@ public class LaunchModuleTest extends BaseModuleRecordActionTest<LaunchModule> {
         cr = actionUnderTest.applyUpdatesToCourseRecord(cr);
         assertEquals(State.IN_PROGRESS, cr.getState());
         assertEquals(State.IN_PROGRESS, cr.getModuleRecords().stream().findFirst().get().getState());
+    }
+
+    @Test
+    public void testLaunchModuleDisliked() {
+        CourseRecord cr = new CourseRecord();
+        cr.setPreference(Preference.DISLIKED);
+        cr = actionUnderTest.applyUpdatesToCourseRecord(cr);
+        assertEquals(State.IN_PROGRESS, cr.getState());
+        assertEquals(State.IN_PROGRESS, cr.getModuleRecords().stream().findFirst().get().getState());
+        assertNull(cr.getPreference());
     }
 
     /**


### PR DESCRIPTION
- Set course record preference to null when an action is taken against any modules within the course