### PR TITLE
LC-3667 Batch course catalogue requests

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,7 @@ reportService.requestCourseCompletionReportValidBaseUrls=${ui.management.baseUrl
 ## learning-catalogue service properties
 learningCatalogue.serviceUrl=${LEARNING_CATALOGUE_SERVICE_URL:http://localhost:9001}
 learningCatalogue.courseUrl=/courses
+learningCatalogue.courseBatchSize=${LEARNING_CATALOGUE_COURSE_BATCH_SIZE:20}
 learningCatalogue.courseV2Url=/v2/${learningCatalogue.courseUrl}
 ## CSRS properties
 csrs.organisationalUnitMaxPageSize=${ORGANISATIONAL_UNIT_MAX_PAGE_SIZE:100}

--- a/src/test/java/uk/gov/cabinetoffice/csl/util/stub/LearningCatalogueStubService.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/util/stub/LearningCatalogueStubService.java
@@ -45,7 +45,7 @@ public class LearningCatalogueStubService {
     public StubMapping getCourses(List<String> courseIds, String response) {
         return stubFor(
                 WireMock.get(urlPathEqualTo("/learning_catalogue/courses"))
-                        .withQueryParam("courseId", equalTo(String.join(",", courseIds)))
+                        .withQueryParam("courseId", including(courseIds.toArray(String[]::new)))
                         .withHeader("Authorization", equalTo("Bearer token"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
- When fetching courses from the learning catalogue, using batching to ensure request headers don't get too large