### PR TITLE
LC-3687 correctly set status of video and elearning modules on launch

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/LaunchModule.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learnerrecord/actions/module/LaunchModule.java
@@ -8,7 +8,9 @@ public class LaunchModule implements IModuleAction {
 
     @Override
     public ModuleRecord applyUpdates(ModuleRecord moduleRecord) {
-        moduleRecord.setState(State.IN_PROGRESS);
+        if (!moduleRecord.getState().equals(State.COMPLETED)) {
+            moduleRecord.setState(State.IN_PROGRESS);
+        }
         return moduleRecord;
     }
 


### PR DESCRIPTION
- Don't revert a video / elearning module back to IN_PROGRESS if it is already completed