### PR TITLE
LC-3817 learning period start time

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/domain/learningcatalogue/LearningPeriod.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/domain/learningcatalogue/LearningPeriod.java
@@ -20,7 +20,7 @@ public class LearningPeriod implements Serializable {
 
     @JsonIgnore
     public LocalDateTime getStartDateAsDateTime() {
-        return startDate == null ? LocalDateTime.MIN : startDate.atTime(LocalTime.MAX);
+        return startDate == null ? LocalDateTime.MIN : startDate.atTime(LocalTime.MIN);
     }
 
 }


### PR DESCRIPTION
- Calculate the learning period start timestamp using the start of the day, rather than the end