### PR TITLE
LC-4175 cache enhancements

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/config/redis/CustomRedisCache.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/config/redis/CustomRedisCache.java
@@ -1,0 +1,24 @@
+package uk.gov.cabinetoffice.csl.config.redis;
+
+import org.springframework.data.redis.cache.RedisCache;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+
+import java.time.Duration;
+
+public class CustomRedisCache extends RedisCache implements ITtlCache {
+
+    private final RedisCacheWriter cacheWriter;
+
+    protected CustomRedisCache(String name, RedisCacheWriter cacheWriter, RedisCacheConfiguration cacheConfiguration) {
+        super(name, cacheWriter, cacheConfiguration);
+        this.cacheWriter = cacheWriter;
+    }
+
+    public void put(Object key, Object value, Long ttlSeconds) {
+        byte[] binaryKey = serializeCacheKey(createCacheKey(key));
+        byte[] binaryValue = serializeCacheValue(preProcessCacheValue(value));
+        Duration timeToLive = Duration.ofSeconds(ttlSeconds);
+        cacheWriter.put(getName(), binaryKey, binaryValue, timeToLive);
+    }
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/config/redis/CustomRedisCacheManager.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/config/redis/CustomRedisCacheManager.java
@@ -1,0 +1,32 @@
+package uk.gov.cabinetoffice.csl.config.redis;
+
+import org.springframework.cache.Cache;
+import org.springframework.data.redis.cache.RedisCache;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+
+import java.util.Map;
+
+public class CustomRedisCacheManager extends RedisCacheManager {
+
+    private final RedisCacheWriter cacheWriter;
+    private final RedisCacheConfiguration defaultCacheConfiguration;
+
+    public CustomRedisCacheManager(RedisCacheWriter cacheWriter, RedisCacheConfiguration defaultCacheConfiguration, Map<String, RedisCacheConfiguration> initialCacheConfigurations) {
+        super(cacheWriter, defaultCacheConfiguration, initialCacheConfigurations);
+        this.cacheWriter = cacheWriter;
+        this.defaultCacheConfiguration = defaultCacheConfiguration;
+    }
+
+    @Override
+    protected RedisCache createRedisCache(String name, RedisCacheConfiguration cacheConfig) {
+        return new CustomRedisCache(name, cacheWriter, cacheConfig != null ? cacheConfig : defaultCacheConfiguration);
+    }
+
+    public CustomRedisCache getCustomRedisCache(String name) {
+        Cache cache = super.getCache(name);
+        return (CustomRedisCache) cache;
+    }
+
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/config/redis/CustomRedisCaches.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/config/redis/CustomRedisCaches.java
@@ -1,0 +1,38 @@
+package uk.gov.cabinetoffice.csl.config.redis;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Course;
+import uk.gov.cabinetoffice.csl.util.TtlObjectCache;
+
+@Configuration
+@ConditionalOnProperty(
+        prefix = "spring.cache",
+        name = {"type"},
+        havingValue = "redis",
+        matchIfMissing = true
+)
+public class CustomRedisCaches {
+
+    private final RedisCacheConfig redisCacheConfig;
+
+    public CustomRedisCaches(RedisCacheConfig redisCacheConfig) {
+        this.redisCacheConfig = redisCacheConfig;
+    }
+
+    @Bean
+    public CustomRedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheWriter cacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory);
+        return new CustomRedisCacheManager(cacheWriter, redisCacheConfig.getDefault(), redisCacheConfig.getAsDefaultConfigMap());
+    }
+
+    @Bean
+    public TtlObjectCache<Course> courseCatalogueCache(CustomRedisCacheManager cacheManager) {
+        CustomRedisCache cache = cacheManager.getCustomRedisCache("catalogue-course");
+        return new TtlObjectCache<>(cache, Course.class);
+    }
+
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/config/redis/ITtlCache.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/config/redis/ITtlCache.java
@@ -1,0 +1,9 @@
+package uk.gov.cabinetoffice.csl.config.redis;
+
+import org.springframework.cache.Cache;
+
+public interface ITtlCache extends Cache {
+
+    void put(Object key, Object value, Long ttlSeconds);
+
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/config/redis/RedisCacheConfig.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/config/redis/RedisCacheConfig.java
@@ -8,13 +8,20 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.springframework.data.redis.cache.RedisCacheConfiguration.defaultCacheConfig;
+
 @ConfigurationProperties(prefix = "spring.cache.redis")
 @RequiredArgsConstructor
 @Getter
 public class RedisCacheConfig {
 
     private final String keyPrefix;
+    private final Integer defaultTtl;
     private final Map<String, RedisCacheConfigurationProps> caches;
+
+    public RedisCacheConfiguration getDefault() {
+        return defaultCacheConfig();
+    }
 
     public Map<String, RedisCacheConfiguration> getAsDefaultConfigMap() {
         return caches

--- a/src/main/java/uk/gov/cabinetoffice/csl/config/redis/RedisCaches.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/config/redis/RedisCaches.java
@@ -1,31 +1,20 @@
 package uk.gov.cabinetoffice.csl.config.redis;
 
-import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import uk.gov.cabinetoffice.csl.client.csrs.ICSRSClient;
 import uk.gov.cabinetoffice.csl.domain.learnerrecord.NullableModuleRecord;
 import uk.gov.cabinetoffice.csl.domain.learnerrecord.record.LearnerRecord;
-import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Course;
 import uk.gov.cabinetoffice.csl.service.csrs.OrganisationalUnitMapCache;
 import uk.gov.cabinetoffice.csl.service.learningCatalogue.CourseAudienceMetadataMapCache;
 import uk.gov.cabinetoffice.csl.service.learningCatalogue.RequiredLearningMapCache;
 import uk.gov.cabinetoffice.csl.util.ModuleRecordCache;
 import uk.gov.cabinetoffice.csl.util.ObjectCache;
 
-import java.util.Map;
-
 @Configuration
 public class RedisCaches {
-
-    private final RedisCacheConfig redisCacheConfig;
-
-    public RedisCaches(RedisCacheConfig redisCacheConfig) {
-        this.redisCacheConfig = redisCacheConfig;
-    }
 
     @Bean
     public RequiredLearningMapCache requiredLearningMapCache(CacheManager cacheManager) {
@@ -37,12 +26,6 @@ public class RedisCaches {
     public CourseAudienceMetadataMapCache courseAudienceMetadataMapCache(CacheManager cacheManager) {
         Cache cache = cacheManager.getCache("catalogue-course");
         return new CourseAudienceMetadataMapCache(cache);
-    }
-
-    @Bean
-    public ObjectCache<Course> courseCatalogueCache(CacheManager cacheManager) {
-        Cache cache = cacheManager.getCache("catalogue-course");
-        return new ObjectCache<>(cache, Course.class);
     }
 
     @Bean
@@ -63,10 +46,5 @@ public class RedisCaches {
         return new OrganisationalUnitMapCache(cache, client);
     }
 
-    @Bean
-    public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
-        Map<String, RedisCacheConfiguration> configs = redisCacheConfig.getAsDefaultConfigMap();
-        return (builder) -> builder.withInitialCacheConfigurations(configs);
-    }
 
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/learningCatalogue/LearningCatalogueService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/learningCatalogue/LearningCatalogueService.java
@@ -14,8 +14,10 @@ import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Module;
 import uk.gov.cabinetoffice.csl.domain.learningcatalogue.event.Event;
 import uk.gov.cabinetoffice.csl.domain.learningcatalogue.event.EventStatus;
 import uk.gov.cabinetoffice.csl.util.CacheGetMultipleOp;
-import uk.gov.cabinetoffice.csl.util.ObjectCache;
+import uk.gov.cabinetoffice.csl.util.IUtilService;
+import uk.gov.cabinetoffice.csl.util.TtlObjectCache;
 
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -25,7 +27,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class LearningCatalogueService {
 
-    private final ObjectCache<Course> cache;
+    private final IUtilService utilService;
+    private final TtlObjectCache<Course> cache;
     private final RequiredLearningMapCache requiredLearningMapCache;
     private final CourseAudienceMetadataMapCache courseAudienceMetadataMapCache;
     private final ILearningCatalogueClient client;
@@ -84,7 +87,7 @@ public class LearningCatalogueService {
             if (!result.getCacheMisses().isEmpty()) {
                 client.getCourses(result.getCacheMisses()).forEach(course -> {
                     courses.add(course);
-                    cache.put(course);
+                    cache.put(course, utilService.getDurationUntilTomorrow(ChronoUnit.SECONDS));
                 });
             }
             return courses;
@@ -156,7 +159,7 @@ public class LearningCatalogueService {
         event.setStatus(EventStatus.CANCELLED);
         event = client.updateEvent(course.getCacheableId(), module.getId(), event);
         course.updateEvent(module.getId(), event);
-        cache.put(course);
+        cache.put(course, utilService.getDurationUntilTomorrow(ChronoUnit.SECONDS));
     }
 
     public CourseSearchResults searchWithinCourses(Collection<String> allLearningPlanCourseIds, String q, int page, int size, Sort.Direction sort) {

--- a/src/main/java/uk/gov/cabinetoffice/csl/util/IUtilService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/util/IUtilService.java
@@ -1,12 +1,15 @@
 package uk.gov.cabinetoffice.csl.util;
 
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalUnit;
 import java.util.List;
 
 public interface IUtilService {
     String generateUUID();
 
     LocalDateTime getNowDateTime();
+
+    Long getDurationUntilTomorrow(TemporalUnit unit);
 
     <T> List<List<T>> batchList(List<T> list, Integer batchSize);
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/util/ObjectCache.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/util/ObjectCache.java
@@ -19,7 +19,13 @@ public class ObjectCache<T extends Cacheable> {
 
     public T get(String id) {
         log.debug("{} cache get object with ID : {}", getCacheName(), id);
-        return cache.get(id, clazz);
+        try {
+            return cache.get(id, clazz);
+        } catch (IllegalStateException e) {
+            log.warn("IllegalStateException when fetching object from cache");
+            evict(id);
+            return null;
+        }
     }
 
     public CacheGetMultipleOp<T> getMultiple(Collection<String> ids) {

--- a/src/main/java/uk/gov/cabinetoffice/csl/util/TtlObjectCache.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/util/TtlObjectCache.java
@@ -1,0 +1,22 @@
+package uk.gov.cabinetoffice.csl.util;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.cabinetoffice.csl.config.redis.ITtlCache;
+
+@Slf4j
+@Getter
+public class TtlObjectCache<T extends Cacheable> extends ObjectCache<T> {
+
+    private final ITtlCache cache;
+
+    public TtlObjectCache(ITtlCache cache, Class<T> clazz) {
+        super(cache, clazz);
+        this.cache = cache;
+    }
+
+    public void put(T object, Long ttlSeconds) {
+        log.debug("{} cache put object: {} with id {}. TTL: {}", getCacheName(), object.getCacheableId(), object, ttlSeconds);
+        cache.put(object.getCacheableId(), object, ttlSeconds);
+    }
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/util/UtilService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/util/UtilService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalUnit;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -23,6 +25,13 @@ public class UtilService implements IUtilService {
     @Override
     public LocalDateTime getNowDateTime() {
         return LocalDateTime.now(clock);
+    }
+
+    @Override
+    public Long getDurationUntilTomorrow(TemporalUnit unit) {
+        LocalDateTime now = getNowDateTime();
+        LocalDateTime tomorrowStart = now.toLocalDate().plusDays(1).atStartOfDay();
+        return Duration.between(now, tomorrowStart).get(unit);
     }
 
     @Override

--- a/src/test/java/uk/gov/cabinetoffice/csl/configuration/MockCacheConfig.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/configuration/MockCacheConfig.java
@@ -1,0 +1,22 @@
+package uk.gov.cabinetoffice.csl.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import uk.gov.cabinetoffice.csl.config.redis.ITtlCache;
+import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Course;
+import uk.gov.cabinetoffice.csl.util.TtlObjectCache;
+
+import static org.mockito.Mockito.mock;
+
+@Configuration
+public class MockCacheConfig {
+
+    @Bean
+    @Primary
+    public TtlObjectCache<Course> mockCourseCatalogueCache() {
+        ITtlCache cache = mock(ITtlCache.class);
+        return new TtlObjectCache<>(cache, Course.class);
+    }
+
+}

--- a/src/test/java/uk/gov/cabinetoffice/csl/configuration/MockClockConfig.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/configuration/MockClockConfig.java
@@ -14,6 +14,10 @@ public class MockClockConfig {
     @Bean
     @Primary
     public Clock getMockClock() {
+        return MockClockConfig.getClock();
+    }
+
+    public static Clock getClock() {
         return Clock.fixed(Instant.parse("2023-01-01T10:00:00.000Z"), ZoneId.of("Europe/London"));
     }
 }

--- a/src/test/java/uk/gov/cabinetoffice/csl/integration/IntegrationTestBase.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/integration/IntegrationTestBase.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import uk.gov.cabinetoffice.csl.configuration.MockCacheConfig;
 import uk.gov.cabinetoffice.csl.configuration.TestConfig;
 import uk.gov.cabinetoffice.csl.util.CSLServiceWireMockServer;
 import uk.gov.cabinetoffice.csl.util.CslTestUtil;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"wiremock", "no-redis"})
-@Import(TestConfig.class)
+@Import({TestConfig.class, MockCacheConfig.class})
 public class IntegrationTestBase extends CSLServiceWireMockServer {
 
     protected MockMvc mockMvc;

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/LearningCatalogueServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/LearningCatalogueServiceTest.java
@@ -2,17 +2,18 @@ package uk.gov.cabinetoffice.csl.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.cabinetoffice.csl.client.courseCatalogue.ILearningCatalogueClient;
+import uk.gov.cabinetoffice.csl.configuration.MockClockConfig;
 import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Course;
+import uk.gov.cabinetoffice.csl.service.learningCatalogue.CourseAudienceMetadataMapCache;
 import uk.gov.cabinetoffice.csl.service.learningCatalogue.LearningCatalogueService;
+import uk.gov.cabinetoffice.csl.service.learningCatalogue.RequiredLearningMapCache;
 import uk.gov.cabinetoffice.csl.util.CacheGetMultipleOp;
 import uk.gov.cabinetoffice.csl.util.IUtilService;
 import uk.gov.cabinetoffice.csl.util.TtlObjectCache;
+import uk.gov.cabinetoffice.csl.util.UtilService;
 
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -23,16 +24,14 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class LearningCatalogueServiceTest {
 
-    @Mock
-    private IUtilService utilService;
+    private final TtlObjectCache<Course> cache = mock(TtlObjectCache.class);
 
-    @Mock
-    private TtlObjectCache<Course> cache;
-    @Mock
-    private ILearningCatalogueClient client;
+    private final IUtilService utilService = new UtilService(MockClockConfig.getClock());
 
-    @InjectMocks
-    private LearningCatalogueService learningCatalogueService;
+    private final ILearningCatalogueClient client = mock(ILearningCatalogueClient.class);
+
+    private final LearningCatalogueService learningCatalogueService = new LearningCatalogueService(utilService, cache,
+            mock(RequiredLearningMapCache.class), mock(CourseAudienceMetadataMapCache.class), client);
 
     @Test
     void getCoursesWithFullCacheHit() {
@@ -56,7 +55,6 @@ public class LearningCatalogueServiceTest {
 
     @Test
     void getCoursesWithPartialCacheHit() {
-        when(utilService.getDurationUntilTomorrow(ChronoUnit.SECONDS)).thenReturn(1L);
         Course course1 = new Course();
         course1.setId("course1");
         Course course2 = new Course();
@@ -74,6 +72,6 @@ public class LearningCatalogueServiceTest {
         assertEquals("course1", result.get(0).getCacheableId());
         assertEquals("course2", result.get(1).getCacheableId());
         assertEquals("cache-miss-course3", result.get(2).getCacheableId());
-        verify(cache, atLeastOnce()).put(course3, 1L);
+        verify(cache, atLeastOnce()).put(course3, 50400L);
     }
 }

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/LearningCatalogueServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/LearningCatalogueServiceTest.java
@@ -9,8 +9,10 @@ import uk.gov.cabinetoffice.csl.client.courseCatalogue.ILearningCatalogueClient;
 import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Course;
 import uk.gov.cabinetoffice.csl.service.learningCatalogue.LearningCatalogueService;
 import uk.gov.cabinetoffice.csl.util.CacheGetMultipleOp;
-import uk.gov.cabinetoffice.csl.util.ObjectCache;
+import uk.gov.cabinetoffice.csl.util.IUtilService;
+import uk.gov.cabinetoffice.csl.util.TtlObjectCache;
 
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -22,7 +24,10 @@ import static org.mockito.Mockito.*;
 public class LearningCatalogueServiceTest {
 
     @Mock
-    private ObjectCache<Course> cache;
+    private IUtilService utilService;
+
+    @Mock
+    private TtlObjectCache<Course> cache;
     @Mock
     private ILearningCatalogueClient client;
 
@@ -51,6 +56,7 @@ public class LearningCatalogueServiceTest {
 
     @Test
     void getCoursesWithPartialCacheHit() {
+        when(utilService.getDurationUntilTomorrow(ChronoUnit.SECONDS)).thenReturn(1L);
         Course course1 = new Course();
         course1.setId("course1");
         Course course2 = new Course();
@@ -68,6 +74,6 @@ public class LearningCatalogueServiceTest {
         assertEquals("course1", result.get(0).getCacheableId());
         assertEquals("course2", result.get(1).getCacheableId());
         assertEquals("cache-miss-course3", result.get(2).getCacheableId());
-        verify(cache, atLeastOnce()).put(course3);
+        verify(cache, atLeastOnce()).put(course3, 1L);
     }
 }

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/learningCatalogue/LearningCatalogueServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/learningCatalogue/LearningCatalogueServiceTest.java
@@ -6,7 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.cabinetoffice.csl.domain.learningcatalogue.Course;
-import uk.gov.cabinetoffice.csl.util.ObjectCache;
+import uk.gov.cabinetoffice.csl.util.TtlObjectCache;
 
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.verify;
@@ -21,7 +21,7 @@ class LearningCatalogueServiceTest {
     CourseAudienceMetadataMapCache courseAudienceMetadataMapCache;
 
     @Mock
-    ObjectCache<Course> courseObjectCache;
+    TtlObjectCache<Course> courseObjectCache;
 
     @InjectMocks
     LearningCatalogueService learningCatalogueService;


### PR DESCRIPTION
- Handle class mismatch errors (`IllegalStateException.class`) when fetching from the cache. This occurs after releases when we've updated a cacheable model, such as the course class. Java tries to serialise the previous version of the class into the new version and we get an exception. This bubbles all the way up to the frontend, causing a sorry page to appear for most transactions. This change catches that exception, evicts the existing (old) value and returns `null`, which will prompt the caller to fetch a fresh version of the object.
- Introduce a TTL for course objects. Unlike the TS implementation of Redis, Java does not allow dynamically setting TTL on the `set` command out of the box. This change introduces a custom redis cache that allows setting TTL at runtime. course cache entries are then set to expire at the end of the current day, which is important as the learning period needs to be recalculated each day 
