### PR TITLE
LC-3965: Fix Add to Learning Plan bug

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/service/learning/LearningPlanService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/learning/LearningPlanService.java
@@ -63,7 +63,7 @@ public class LearningPlanService {
                     if (courseToBeDisplayed != null) {
                         LearnerRecordEvent latestEvent = latestEventForCourseMap.get(courseId);
                         if (!(latestEvent != null && latestEvent.getActionType().equals(REMOVE_FROM_LEARNING_PLAN)
-                                && latestEvent.getEventTimestamp().isAfter(requiredModuleRecords.getLatestUpdatedDate()))) {
+                                && !latestEvent.getEventTimestamp().isBefore(requiredModuleRecords.getLatestUpdatedDate()))) {
                             coursesToBeDisplayed(homepageCompleteLearningPlanCourses, requiredModuleRecords, courseToBeDisplayed,
                                     bookedLearningPlanCourses, user, learningPlanCourses);
                         }


### PR DESCRIPTION
This change fixes a bug which displays a course not in the learning plan as being in the learning plan on the homepage, when the latest event timestamp is exactly equal to the timestamp of the latest module record update.